### PR TITLE
Added font-awesome 'style' option for social links

### DIFF
--- a/config.js
+++ b/config.js
@@ -13,19 +13,22 @@ module.exports = {
   // social
   socialLinks: [
     {
+      style: 'brands',
       icon: 'fa-github',
       name: 'Github',
       url: 'https://github.com/anubhavsrivastava',
     },
     {
+      style: 'brands',
       icon: 'fa-twitter',
       name: 'Twitter',
       url: 'https://twitter.com/onlyanubhav',
     },
     {
-      icon: 'fa-facebook',
-      name: 'Facebook',
-      url: 'https://facebook.com/theanubhav',
+      style: 'solid',
+      icon: 'fa-envelope',
+      name: 'Email',
+      url: 'mailto:test@example.com',
     },
   ],
 };

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -5,10 +5,10 @@ export default function Footer() {
     <footer id="footer">
       <ul className="icons">
         {config.socialLinks.map(social => {
-          const { icon, name, url } = social;
+          const { style, icon, name, url } = social;
           return (
             <li key={url}>
-              <a href={url} className={`icon brands ${icon}`}>
+              <a href={url} className={`icon ${style} ${icon}`}>
                 <span className="label">{name}</span>
               </a>
             </li>


### PR DESCRIPTION
Ran into issues with using 'fa-envelope'.

Turns out that icon doesn't exist under the 'brands' style for Font-Awesome.  It only exists as solid, regular, and light.

https://fontawesome.com/icons?d=gallery&q=envelope

This update should allow users to define which style of the icon they want to use within `config.js` instead of relying on the hard coded 'brands' style.